### PR TITLE
Dev-1425 [Авто-тесты] Проставлять data-qa атрибуты элементам вопросов анкеты регистрации на Афише и ЕП4

### DIFF
--- a/linter_config.js
+++ b/linter_config.js
@@ -17,10 +17,14 @@ module.exports = {
     "prettier/prettier": "warn",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/semi": ["error", "always"],
-    "@typescript-eslint/interface-name-prefix": ["error", {
-      "prefixWithI": "always",
-      "allowUnderscorePrefix": false
-    }],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      { // требуем I-префикс
+        selector: "interface",
+        format: ["PascalCase"],
+        custom: { regex: "^I[A-Z]", match: true },
+      },
+    ],
     "no-console": ["error", { allow: ["warn", "error"] }],
     "no-param-reassign": "error",
     "no-unused-vars": "error",


### PR DESCRIPTION
[ref] [m] - обновление правила для именования интерфейсов, удалено устаревшее правило @typescript-eslint/interface-name-prefix, добавлено новое правило naming-convention с I-префиксом

https://timepad.evateam.ru/project/Task/DEV-1425